### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,5 @@ numpy
 opencv-python
 soundfile
 sox
-torch==1.12.1+cu113
-torchvision==0.13.1+cu113
-torchaudio==0.12.1
 tqdm
 wandb


### PR DESCRIPTION
Removed torch entries from requirements.txt since the README.md instructs users to install via `pip` with:
```
pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 torchaudio==0.12.1 --extra-index-url https://download.pytorch.org/whl/cu113
```